### PR TITLE
Fix ARM runner label for public repos

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64
-            runner: ubuntu-22.04-arm64-4core
+            runner: ubuntu-22.04-arm
     
     runs-on: ${{ matrix.runner }}
     permissions:


### PR DESCRIPTION
Use `ubuntu-22.04-arm` (free for public repos) instead of `ubuntu-22.04-arm64-4core` (paid larger runner).