### PR TITLE
Add marmotd (MLS over Nostr) as optional messaging provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN cargo build --release
 
 # Stage 4: Build marmotd (optional MLS messaging sidecar)
 FROM chef AS marmotd-builder
-ARG MARMOTD_VERSION=0.3.2
+ARG MARMOTD_VERSION=0.5.1
 RUN git clone --depth 1 --branch marmotd-v${MARMOTD_VERSION} https://github.com/sledtools/pika.git /marmotd-src
 WORKDIR /marmotd-src
 RUN cargo build -p marmotd --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,14 @@ COPY crates/ crates/
 
 RUN cargo build --release
 
-# Stage 4: Runtime
+# Stage 4: Build marmotd (optional MLS messaging sidecar)
+FROM chef AS marmotd-builder
+ARG MARMOTD_VERSION=0.3.2
+RUN git clone --depth 1 --branch marmotd-v${MARMOTD_VERSION} https://github.com/sledtools/pika.git /marmotd-src
+WORKDIR /marmotd-src
+RUN cargo build -p marmotd --release
+
+# Stage 5: Runtime
 FROM docker.io/debian:bookworm-slim
 
 # Install runtime dependencies and comprehensive CLI toolset
@@ -140,6 +147,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     toml \
     rich
 
+# Copy marmotd binary (MLS messaging sidecar, built from pika source)
+COPY --from=marmotd-builder /marmotd-src/target/release/marmotd /usr/local/bin/marmotd
+
 # Create non-root user
 RUN useradd -m -u 1000 sage
 
@@ -151,8 +161,8 @@ COPY --from=builder /app/target/release/sage /app/sage
 # Copy migrations for diesel
 COPY --from=builder /app/crates/sage-core/migrations /app/migrations
 
-# Create workspace directory
-RUN mkdir -p /workspace && chown sage:sage /workspace
+# Create workspace and marmot state directories
+RUN mkdir -p /workspace /data/marmot-state && chown sage:sage /workspace /data/marmot-state
 
 # Run as non-root user
 USER sage

--- a/crates/sage-core/migrations/2026-02-22-010953-0000_add_reply_context_to_chat_contexts/down.sql
+++ b/crates/sage-core/migrations/2026-02-22-010953-0000_add_reply_context_to_chat_contexts/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_contexts DROP COLUMN reply_context;

--- a/crates/sage-core/migrations/2026-02-22-010953-0000_add_reply_context_to_chat_contexts/up.sql
+++ b/crates/sage-core/migrations/2026-02-22-010953-0000_add_reply_context_to_chat_contexts/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_contexts ADD COLUMN reply_context TEXT;

--- a/crates/sage-core/src/config.rs
+++ b/crates/sage-core/src/config.rs
@@ -1,5 +1,13 @@
 use anyhow::{Context, Result};
 
+use crate::marmot::MarmotConfig;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessengerType {
+    Signal,
+    Marmot,
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Config {
@@ -11,11 +19,22 @@ pub struct Config {
 
     pub database_url: String,
 
+    /// Which messaging provider to use
+    pub messenger_type: MessengerType,
+
+    // Signal-specific config
     pub signal_phone_number: Option<String>,
     pub signal_allowed_users: Vec<String>,
     /// If set, connect to signal-cli daemon via TCP instead of spawning subprocess
     pub signal_cli_host: Option<String>,
     pub signal_cli_port: u16,
+
+    // Marmot-specific config
+    pub marmot_binary: String,
+    pub marmot_relays: Vec<String>,
+    pub marmot_state_dir: String,
+    pub marmot_allowed_pubkeys: Vec<String>,
+    pub marmot_auto_accept_welcomes: bool,
 
     pub brave_api_key: Option<String>,
 
@@ -40,6 +59,15 @@ impl Config {
 
             database_url: std::env::var("DATABASE_URL").context("DATABASE_URL must be set")?,
 
+            messenger_type: match std::env::var("MESSENGER")
+                .unwrap_or_else(|_| "signal".to_string())
+                .to_lowercase()
+                .as_str()
+            {
+                "marmot" => MessengerType::Marmot,
+                _ => MessengerType::Signal,
+            },
+
             signal_phone_number: std::env::var("SIGNAL_PHONE_NUMBER").ok(),
             signal_allowed_users: std::env::var("SIGNAL_ALLOWED_USERS")
                 .map(|s| s.split(',').map(|u| u.trim().to_string()).collect())
@@ -49,6 +77,36 @@ impl Config {
                 .unwrap_or_else(|_| "7583".to_string())
                 .parse()
                 .unwrap_or(7583),
+
+            marmot_binary: std::env::var("MARMOT_BINARY").unwrap_or_else(|_| "marmotd".to_string()),
+            marmot_relays: std::env::var("MARMOT_RELAYS")
+                .map(|s| {
+                    s.split(',')
+                        .map(|r| r.trim().to_string())
+                        .filter(|r| !r.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
+            marmot_state_dir: std::env::var("MARMOT_STATE_DIR")
+                .unwrap_or_else(|_| "/data/marmot-state".to_string()),
+            marmot_allowed_pubkeys: std::env::var("MARMOT_ALLOWED_PUBKEYS")
+                .map(|s| {
+                    s.split(',')
+                        .map(|p| p.trim().to_string())
+                        .filter(|p| !p.is_empty())
+                        .map(|p| {
+                            if p == "*" {
+                                p
+                            } else {
+                                crate::marmot::normalize_pubkey(&p).unwrap_or(p)
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            marmot_auto_accept_welcomes: std::env::var("MARMOT_AUTO_ACCEPT_WELCOMES")
+                .map(|s| s != "false" && s != "0")
+                .unwrap_or(true),
 
             brave_api_key: std::env::var("BRAVE_API_KEY").ok(),
 
@@ -60,5 +118,22 @@ impl Config {
                 .parse()
                 .context("HTTP_PORT must be a valid port number")?,
         })
+    }
+
+    pub fn marmot_config(&self) -> MarmotConfig {
+        MarmotConfig {
+            binary_path: self.marmot_binary.clone(),
+            relays: self.marmot_relays.clone(),
+            state_dir: self.marmot_state_dir.clone(),
+            allowed_pubkeys: self.marmot_allowed_pubkeys.clone(),
+            auto_accept_welcomes: self.marmot_auto_accept_welcomes,
+        }
+    }
+
+    pub fn allowed_users(&self) -> &[String] {
+        match self.messenger_type {
+            MessengerType::Signal => &self.signal_allowed_users,
+            MessengerType::Marmot => &self.marmot_allowed_pubkeys,
+        }
     }
 }

--- a/crates/sage-core/src/lib.rs
+++ b/crates/sage-core/src/lib.rs
@@ -4,7 +4,9 @@
 
 pub mod agent_manager;
 pub mod config;
+pub mod marmot;
 pub mod memory;
+pub mod messenger;
 pub mod sage_agent;
 pub mod scheduler;
 pub mod scheduler_tools;

--- a/crates/sage-core/src/main.rs
+++ b/crates/sage-core/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
             info!("  Relays: {:?}", marmot_config.relays);
             info!("  State dir: {}", marmot_config.state_dir);
 
-            let (client, stdout, _child) = marmot::spawn_marmot(&marmot_config)?;
+            let (client, stdout) = marmot::spawn_marmot(&marmot_config)?;
             let writer = marmot::writer_handle(&client);
             let group_routes = marmot::group_routes_handle(&client);
             let messenger: Arc<Mutex<dyn Messenger>> = Arc::new(Mutex::new(client));

--- a/crates/sage-core/src/main.rs
+++ b/crates/sage-core/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
             info!("  Relays: {:?}", marmot_config.relays);
             info!("  State dir: {}", marmot_config.state_dir);
 
-            let (client, _initial_stdout) = marmot::spawn_marmot(&marmot_config)?;
+            let client = marmot::new_marmot_client(&marmot_config)?;
             let writer = marmot::writer_handle(&client);
             let group_routes = marmot::group_routes_handle(&client);
             let child = marmot::child_handle(&client);

--- a/crates/sage-core/src/main.rs
+++ b/crates/sage-core/src/main.rs
@@ -328,7 +328,7 @@ async fn main() -> Result<()> {
 
                 // Get or create agent for this conversation
                 // For Signal: keyed by user UUID (reply_to == source)
-                // For Marmot: keyed by group ID (reply_to == nostr_group_id)
+                // For Marmot: keyed by sender pubkey (reply_to == from_pubkey)
                 let (agent_id, agent) = match agent_manager.get_or_create_agent(
                     &msg.reply_to,
                     context_type,

--- a/crates/sage-core/src/marmot.rs
+++ b/crates/sage-core/src/marmot.rs
@@ -420,6 +420,7 @@ pub async fn run_marmot_receive_loop(
                                 attachments: vec![],
                                 timestamp: created_at,
                                 reply_to: from_pubkey.to_string(),
+                                reply_context: Some(group_id.to_string()),
                             };
 
                             if tx.blocking_send(msg).is_err() {

--- a/crates/sage-core/src/marmot.rs
+++ b/crates/sage-core/src/marmot.rs
@@ -171,10 +171,13 @@ pub fn spawn_marmot(
 
     cmd.arg("--state-dir").arg(&config.state_dir);
 
-    for pk in &config.allowed_pubkeys {
-        let hex_pk = normalize_pubkey(pk)
-            .with_context(|| format!("invalid MARMOT_ALLOWED_PUBKEYS entry: {}", pk))?;
-        cmd.arg("--allow-pubkey").arg(&hex_pk);
+    let is_wildcard = config.allowed_pubkeys.iter().any(|p| p == "*");
+    if !is_wildcard {
+        for pk in &config.allowed_pubkeys {
+            let hex_pk = normalize_pubkey(pk)
+                .with_context(|| format!("invalid MARMOT_ALLOWED_PUBKEYS entry: {}", pk))?;
+            cmd.arg("--allow-pubkey").arg(&hex_pk);
+        }
     }
 
     cmd.stdin(Stdio::piped())

--- a/crates/sage-core/src/marmot.rs
+++ b/crates/sage-core/src/marmot.rs
@@ -1,0 +1,445 @@
+use anyhow::{anyhow, Context, Result};
+use serde_json::json;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+
+use crate::messenger::{IncomingMessage, Messenger};
+
+const BECH32_CHARSET: &str = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+/// Decode a bech32-encoded string (npub1...) into its raw bytes.
+fn bech32_decode_payload(s: &str) -> Option<Vec<u8>> {
+    let pos = s.rfind('1')?;
+    let data_part = &s[pos + 1..];
+    if data_part.len() < 6 {
+        return None;
+    }
+    let values: Vec<u8> = data_part
+        .chars()
+        .map(|c| BECH32_CHARSET.find(c).map(|i| i as u8))
+        .collect::<Option<Vec<_>>>()?;
+    let data_values = &values[..values.len() - 6];
+    let mut acc: u32 = 0;
+    let mut bits: u32 = 0;
+    let mut result = Vec::new();
+    for &v in data_values {
+        acc = (acc << 5) | (v as u32);
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            result.push((acc >> bits) as u8);
+            acc &= (1 << bits) - 1;
+        }
+    }
+    Some(result)
+}
+
+/// Convert an npub (bech32) or hex pubkey string to hex.
+/// Accepts both "npub1..." and raw 64-char hex.
+pub fn normalize_pubkey(input: &str) -> Result<String> {
+    let trimmed = input.trim();
+    if trimmed.starts_with("npub1") {
+        let bytes =
+            bech32_decode_payload(trimmed).ok_or_else(|| anyhow!("invalid npub: {}", trimmed))?;
+        if bytes.len() != 32 {
+            return Err(anyhow!(
+                "npub decoded to {} bytes, expected 32",
+                bytes.len()
+            ));
+        }
+        Ok(bytes.iter().map(|b| format!("{:02x}", b)).collect())
+    } else if trimmed.len() == 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        Ok(trimmed.to_lowercase())
+    } else {
+        Err(anyhow!(
+            "invalid pubkey (expected npub1... or 64-char hex): {}",
+            trimmed
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MarmotConfig {
+    pub binary_path: String,
+    pub relays: Vec<String>,
+    pub state_dir: String,
+    pub allowed_pubkeys: Vec<String>,
+    pub auto_accept_welcomes: bool,
+}
+
+pub struct MarmotClient {
+    writer: Arc<Mutex<BufWriter<std::process::ChildStdin>>>,
+    request_id: AtomicU64,
+}
+
+impl MarmotClient {
+    fn send_cmd(&self, cmd: serde_json::Value) -> Result<()> {
+        let mut writer = self
+            .writer
+            .lock()
+            .map_err(|e| anyhow!("Lock error: {}", e))?;
+        let cmd_str = serde_json::to_string(&cmd)? + "\n";
+        writer.write_all(cmd_str.as_bytes())?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    fn next_request_id(&self) -> String {
+        self.request_id.fetch_add(1, Ordering::SeqCst).to_string()
+    }
+}
+
+impl Messenger for MarmotClient {
+    fn send_message(&self, recipient: &str, message: &str) -> Result<()> {
+        let id = self.next_request_id();
+        // Find valid UTF-8 boundary for preview
+        let preview_end = {
+            let max_len = 50.min(message.len());
+            let mut end = max_len;
+            while end > 0 && !message.is_char_boundary(end) {
+                end -= 1;
+            }
+            end
+        };
+        info!(
+            "Sending marmot message (req #{}) to group {}: {}...",
+            id,
+            recipient,
+            &message[..preview_end]
+        );
+        self.send_cmd(json!({
+            "cmd": "send_message",
+            "request_id": id,
+            "nostr_group_id": recipient,
+            "content": message
+        }))
+    }
+
+    fn send_typing(&self, recipient: &str, stop: bool) -> Result<()> {
+        if stop {
+            return Ok(());
+        }
+        let id = self.next_request_id();
+        self.send_cmd(json!({
+            "cmd": "send_typing",
+            "request_id": id,
+            "nostr_group_id": recipient
+        }))
+    }
+}
+
+/// Spawn marmotd daemon and return the client, stdout reader, and child process handle.
+pub fn spawn_marmot(
+    config: &MarmotConfig,
+) -> Result<(MarmotClient, std::process::ChildStdout, Child)> {
+    let mut cmd = Command::new(&config.binary_path);
+    cmd.arg("daemon");
+
+    for relay in &config.relays {
+        cmd.arg("--relay").arg(relay);
+    }
+
+    cmd.arg("--state-dir").arg(&config.state_dir);
+
+    for pk in &config.allowed_pubkeys {
+        let hex_pk = normalize_pubkey(pk)
+            .with_context(|| format!("invalid MARMOT_ALLOWED_PUBKEYS entry: {}", pk))?;
+        cmd.arg("--allow-pubkey").arg(&hex_pk);
+    }
+
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    info!(
+        "Spawning marmotd: {} daemon --relay {} --state-dir {}",
+        config.binary_path,
+        config.relays.join(","),
+        config.state_dir
+    );
+
+    let mut child = cmd.spawn().context("Failed to spawn marmotd")?;
+
+    let stdin = child.stdin.take().context("Failed to get marmotd stdin")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("Failed to get marmotd stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("Failed to get marmotd stderr")?;
+
+    // Forward stderr to tracing
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            info!(target: "marmotd", "{}", line);
+        }
+    });
+
+    let writer = Arc::new(Mutex::new(BufWriter::new(stdin)));
+
+    let client = MarmotClient {
+        writer: writer.clone(),
+        request_id: AtomicU64::new(1),
+    };
+
+    Ok((client, stdout, child))
+}
+
+/// Run the marmot receive loop: waits for daemon ready, publishes keypackage,
+/// then listens for incoming messages and auto-accepts welcomes.
+pub async fn run_marmot_receive_loop(
+    stdout: std::process::ChildStdout,
+    writer: Arc<Mutex<BufWriter<std::process::ChildStdin>>>,
+    tx: mpsc::Sender<IncomingMessage>,
+    config: MarmotConfig,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+
+        let send_cmd = |cmd: serde_json::Value| -> Result<()> {
+            let mut w = writer.lock().map_err(|e| anyhow!("Lock error: {}", e))?;
+            let s = serde_json::to_string(&cmd)? + "\n";
+            w.write_all(s.as_bytes())?;
+            w.flush()?;
+            Ok(())
+        };
+
+        // Phase 1: Wait for ready
+        loop {
+            line.clear();
+            if reader.read_line(&mut line)? == 0 {
+                return Err(anyhow!("marmotd closed stdout before ready"));
+            }
+            let event: serde_json::Value = serde_json::from_str(line.trim())
+                .with_context(|| format!("parse marmotd json: {}", line.trim()))?;
+
+            if event.get("type").and_then(|t| t.as_str()) == Some("ready") {
+                let pubkey = event
+                    .get("pubkey")
+                    .and_then(|p| p.as_str())
+                    .unwrap_or("unknown");
+                let npub = event
+                    .get("npub")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("unknown");
+                info!("marmotd ready: pubkey={} npub={}", pubkey, npub);
+                break;
+            }
+        }
+
+        // Phase 2: Publish keypackage
+        let relays: Vec<&str> = config.relays.iter().map(|s| s.as_str()).collect();
+        send_cmd(json!({
+            "cmd": "publish_keypackage",
+            "request_id": "init_kp",
+            "relays": relays
+        }))?;
+
+        loop {
+            line.clear();
+            if reader.read_line(&mut line)? == 0 {
+                return Err(anyhow!("marmotd closed stdout during keypackage publish"));
+            }
+            let event: serde_json::Value = serde_json::from_str(line.trim())
+                .with_context(|| format!("parse marmotd json: {}", line.trim()))?;
+
+            let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            if event_type == "ok"
+                && event.get("request_id").and_then(|id| id.as_str()) == Some("init_kp")
+            {
+                info!("marmotd keypackage published");
+                break;
+            }
+            if event_type == "error"
+                && event.get("request_id").and_then(|id| id.as_str()) == Some("init_kp")
+            {
+                let msg = event
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown error");
+                warn!("marmotd keypackage publish failed: {}", msg);
+                break;
+            }
+        }
+
+        info!("Marmot receive loop started, listening for messages...");
+
+        // Phase 3: Main receive loop
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => {
+                    warn!("marmotd closed stdout");
+                    break;
+                }
+                Ok(_) => {
+                    let event: serde_json::Value = match serde_json::from_str(line.trim()) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            debug!("marmotd non-json output: {} ({})", line.trim(), e);
+                            continue;
+                        }
+                    };
+                    let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                    match event_type {
+                        "welcome_received" => {
+                            let wrapper_id = event
+                                .get("wrapper_event_id")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("");
+                            let from = event
+                                .get("from_pubkey")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("unknown");
+                            let group_name = event
+                                .get("group_name")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("");
+                            info!(
+                                "Marmot welcome received from {} (group: {}, wrapper: {})",
+                                from, group_name, wrapper_id
+                            );
+
+                            if config.auto_accept_welcomes && !wrapper_id.is_empty() {
+                                let req_id = format!("auto_{}", wrapper_id);
+                                if let Err(e) = send_cmd(json!({
+                                    "cmd": "accept_welcome",
+                                    "request_id": req_id,
+                                    "wrapper_event_id": wrapper_id
+                                })) {
+                                    warn!("Failed to auto-accept welcome: {}", e);
+                                }
+                            }
+                        }
+                        "group_joined" => {
+                            let group_id = event
+                                .get("nostr_group_id")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("unknown");
+                            info!("Marmot joined group: {}", group_id);
+                        }
+                        "message_received" => {
+                            let from_pubkey = event
+                                .get("from_pubkey")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("");
+                            let content =
+                                event.get("content").and_then(|x| x.as_str()).unwrap_or("");
+                            let group_id = event
+                                .get("nostr_group_id")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("");
+                            let created_at = event
+                                .get("created_at")
+                                .and_then(|x| x.as_u64())
+                                .unwrap_or(0);
+
+                            if content.is_empty() {
+                                continue;
+                            }
+
+                            let preview_end = {
+                                let max_len = 100.min(content.len());
+                                let mut end = max_len;
+                                while end > 0 && !content.is_char_boundary(end) {
+                                    end -= 1;
+                                }
+                                end
+                            };
+                            info!(
+                                "Marmot message from {} in group {}: {}",
+                                from_pubkey,
+                                group_id,
+                                &content[..preview_end]
+                            );
+
+                            let msg = IncomingMessage {
+                                source: from_pubkey.to_string(),
+                                source_name: None,
+                                message: content.to_string(),
+                                attachments: vec![],
+                                timestamp: created_at,
+                                reply_to: group_id.to_string(),
+                            };
+
+                            if tx.blocking_send(msg).is_err() {
+                                error!("Failed to send marmot message to channel");
+                                break;
+                            }
+                        }
+                        "ok" | "keypackage_published" => {
+                            debug!("marmotd: {}", line.trim());
+                        }
+                        "error" => {
+                            let msg = event
+                                .get("message")
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("unknown");
+                            warn!("marmotd error: {}", msg);
+                        }
+                        _ => {
+                            debug!("marmotd event: {}", line.trim());
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("Error reading from marmotd: {}", e);
+                    break;
+                }
+            }
+        }
+
+        warn!("Marmot receive loop ended");
+        Ok::<_, anyhow::Error>(())
+    })
+    .await??;
+
+    Ok(())
+}
+
+/// Get the shared writer handle from a MarmotClient (for the receive loop).
+pub fn writer_handle(client: &MarmotClient) -> Arc<Mutex<BufWriter<std::process::ChildStdin>>> {
+    client.writer.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_npub() {
+        let hex =
+            normalize_pubkey("npub1gx8my906z8urmgzpcynjlj43ehwc5jket0mc70pkvzkg6k636hmqnwunq7")
+                .unwrap();
+        assert_eq!(
+            hex,
+            "418fb215fa11f83da041c1272fcab1cddd8a4ad95bf78f3c3660ac8d5b51d5f6"
+        );
+    }
+
+    #[test]
+    fn test_normalize_hex_passthrough() {
+        let hex =
+            normalize_pubkey("418fb215fa11f83da041c1272fcab1cddd8a4ad95bf78f3c3660ac8d5b51d5f6")
+                .unwrap();
+        assert_eq!(
+            hex,
+            "418fb215fa11f83da041c1272fcab1cddd8a4ad95bf78f3c3660ac8d5b51d5f6"
+        );
+    }
+
+    #[test]
+    fn test_normalize_invalid() {
+        assert!(normalize_pubkey("not_a_valid_key").is_err());
+        assert!(normalize_pubkey("npub1invalid").is_err());
+    }
+}

--- a/crates/sage-core/src/messenger.rs
+++ b/crates/sage-core/src/messenger.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+
+/// An attachment received from a messaging provider
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct IncomingAttachment {
+    pub file: String,
+    pub content_type: String,
+    pub size: Option<u64>,
+}
+
+/// A message received from a messaging provider
+#[derive(Debug, Clone)]
+pub struct IncomingMessage {
+    /// Unique identifier of the sender (Signal UUID, Nostr pubkey, etc.)
+    pub source: String,
+    pub source_name: Option<String>,
+    pub message: String,
+    pub attachments: Vec<IncomingAttachment>,
+    #[allow(dead_code)]
+    pub timestamp: u64,
+    /// Where to send replies (same as source for Signal, nostr_group_id for Marmot)
+    pub reply_to: String,
+}
+
+/// Trait for sending messages via a messaging provider
+pub trait Messenger: Send + Sync {
+    fn send_message(&self, recipient: &str, message: &str) -> Result<()>;
+    fn send_typing(&self, recipient: &str, stop: bool) -> Result<()>;
+
+    /// Periodic health/refresh check (no-op by default)
+    fn refresh(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/crates/sage-core/src/messenger.rs
+++ b/crates/sage-core/src/messenger.rs
@@ -21,6 +21,9 @@ pub struct IncomingMessage {
     pub timestamp: u64,
     /// Identity key for agent lookup and reply routing (Signal UUID or Marmot pubkey)
     pub reply_to: String,
+    /// Transport-specific routing context to persist (e.g. Marmot nostr_group_id).
+    /// Used to restore reply routing after restarts.
+    pub reply_context: Option<String>,
 }
 
 /// Trait for sending messages via a messaging provider

--- a/crates/sage-core/src/messenger.rs
+++ b/crates/sage-core/src/messenger.rs
@@ -19,7 +19,7 @@ pub struct IncomingMessage {
     pub attachments: Vec<IncomingAttachment>,
     #[allow(dead_code)]
     pub timestamp: u64,
-    /// Where to send replies (same as source for Signal, nostr_group_id for Marmot)
+    /// Identity key for agent lookup and reply routing (Signal UUID or Marmot pubkey)
     pub reply_to: String,
 }
 

--- a/crates/sage-core/src/schema.rs
+++ b/crates/sage-core/src/schema.rs
@@ -128,6 +128,7 @@ diesel::table! {
         context_type -> Varchar,
         display_name -> Nullable<Text>,
         created_at -> Timestamptz,
+        reply_context -> Nullable<Text>,
     }
 }
 

--- a/crates/sage-core/src/signal.rs
+++ b/crates/sage-core/src/signal.rs
@@ -438,6 +438,7 @@ pub fn parse_incoming_message(line: &str) -> Option<IncomingMessage> {
         message: message.to_string(),
         attachments,
         timestamp,
+        reply_context: None,
     })
 }
 


### PR DESCRIPTION
## Summary

Add [marmotd](https://github.com/sledtools/pika) as an optional messaging provider, giving Sage a decentralized MLS-encrypted transport over Nostr relays as an alternative to Signal.

## Changes

**New files:**
- `messenger.rs` — `Messenger` trait abstracting message send/receive, shared `IncomingMessage`/`IncomingAttachment` types
- `marmot.rs` — `MarmotClient` that spawns marmotd as a subprocess, speaks JSONL over stdio, handles welcome auto-accept, keypackage publishing, and pubkey->group routing

**Modified:**
- `config.rs` — `MESSENGER` env var (`signal`|`marmot`), marmot-specific config (relays, state dir, allowed pubkeys, auto-accept), npub (bech32) normalization
- `main.rs` — Messenger-polymorphic event loop via `Arc<Mutex<dyn Messenger>>`, agents keyed by identity (Signal UUID or Nostr pubkey)
- `signal.rs` — Implements `Messenger` trait, uses shared types from `messenger.rs`
- `Dockerfile` — Builds marmotd from pika source (v0.3.2) to avoid GLIBC mismatch with prebuilt binaries
- `justfile` — Messenger-aware start/restart/stop; conditionally skips signal-cli for marmot mode, mounts marmot-state volume

## Design Decisions

- **Pubkey as identity:** Marmot agents are keyed by sender pubkey (not MLS group ID), keeping parity with Signal's 1:1 UUID model. A routing table maps pubkey -> latest group for reply delivery.
- **Optional, not default:** `MESSENGER=signal` remains the default. Set `MESSENGER=marmot` to switch.
- **Build from source:** marmotd prebuilt binaries target Ubuntu 24.04 (GLIBC 2.39), but our runtime is Debian Bookworm (2.36). A dedicated Dockerfile stage builds from the pika repo at the release tag.
- **Future multi-agent:** Comments note where per-group agent threads could be layered on top when multi-agent/subagent support lands.

## Configuration

```env
MESSENGER=marmot
MARMOT_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net
MARMOT_STATE_DIR=/data/marmot-state
MARMOT_ALLOWED_PUBKEYS=npub1...
MARMOT_AUTO_ACCEPT_WELCOMES=true
```

## Testing

- All existing tests pass, fmt/clippy clean
- Docker image builds and runs successfully
- End-to-end tested: Pika client -> marmotd -> Sage agent -> marmotd -> Pika client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-messenger support: choose Signal or Marmot via MESSENGER; unified messaging types and provider selection.
  * Marmot support: optional marmotd sidecar, relay/state config, allowed pubkeys, auto-accept welcomes.
  * Persistent reply context: store and restore per-chat reply_context for routing.

* **Refactor**
  * Unified Messenger interface with shared send/receive/typing and health checks.

* **Chores**
  * Updated startup tooling to handle Marmot state/volumes.

* **Tests**
  * Added unit tests for pubkey normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anthonyronning/sage/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
